### PR TITLE
feat: Add before and after hooks to attribute tests

### DIFF
--- a/spec/matchers/atributos/atributos_spec.rb
+++ b/spec/matchers/atributos/atributos_spec.rb
@@ -2,11 +2,29 @@ require 'pessoa'
 # Para testar os atributos de uma classe, podemos usar o método have_attributes
 
 describe 'Atributos' do
-  it 'have_attributes' do
-    pessoa = Pessoa.new
-    pessoa.nome = 'Bruno'
-    pessoa.idade = 38
+  before(:each) do
+    puts ">>>>>>>> ANTES DE CADA TESTE <<<<<<<<"
+    @pessoa = Pessoa.new
+  end
 
-    expect(pessoa).to have_attributes(nome: starting_with('B'), idade: (be >= 38))
+  after(:each) do
+    @pessoa.nome = 'Sem nome'
+    puts ">>>>>>>> DEPOIS DE CADA TESTE <<<<<<<< #{@pessoa.inspect}"
+  end
+
+  it 'have_attributes' do
+    @pessoa.nome = 'Bruno'
+    puts @pessoa.inspect
+    @pessoa.idade = 38
+
+    expect(@pessoa).to have_attributes(nome: starting_with('B'), idade: (be >= 38))
+  end
+
+  it 'have_attributes' do
+    @pessoa.nome = 'José'
+    puts @pessoa.inspect
+    @pessoa.idade = 25
+
+    expect(@pessoa).to have_attributes(nome: a_string_starting_with('J'), idade: (a_value >= 25))
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,26 @@
 require_relative '../helpers/helper'
 
 RSpec.configure do |config|
+  # Roda antes de toda a suite de testes
+  config.before(:suite) do
+    puts ">>>>>>> Rodando antes de toda a suite de testes >>>>>>>>>>>"
+  end
+
+  # Roda depois de toda a suite de testes
+  config.after(:suite) do
+    puts "<<<<<<<< Rodando depois de toda a suite de testes <<<<<<<<<<"
+  end
+
+  # Roda antes de cada contexto
+  config.before(:context) do
+    puts ">>>>>>> Roda antes de cada contexto >>>>>>>>>>>"
+  end
+
+  # Roda depois de cada contexto
+  config.after(:all) do
+    puts "<<<<<<<< Roda depois de cada contexto <<<<<<<<<<"
+  end
+
   # inclui o modulo Helper em todos os testes.
   config.include Helper
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
The code changes include adding `before` and `after` hooks to the attribute tests in the `atributos_spec.rb` file. These hooks are used to set up and tear down the test environment before and after each test case. The purpose of these changes is to ensure that the `@pessoa` object is properly initialized before each test and reset to its default state after each test.