### PR TITLE
Hooks around 0008

### DIFF
--- a/spec/matchers/atributos/atributos_spec.rb
+++ b/spec/matchers/atributos/atributos_spec.rb
@@ -11,16 +11,26 @@ describe 'Atributos' do
     puts " "
   end
 
-  before(:each) do
-    puts ">>>>>>>> ANTES DE CADA TESTE <<<<<<<<"
-    @pessoa = Pessoa.new
-    puts " "
-  end
+  # before(:each) do
+  #   puts ">>>>>>>> ANTES DE CADA TESTE <<<<<<<<"
+  #   @pessoa = Pessoa.new
+  #   puts " "
+  # end
 
-  after(:each) do
+  # after(:each) do
+  #   @pessoa.nome = 'Sem nome'
+  #   puts ">>>>>>>> DEPOIS DE CADA TESTE <<<<<<<< #{@pessoa.inspect}"
+  #   puts " "
+  # end
+
+  around(:each) do |teste|
+    puts "ANTES"
+    @pessoa = Pessoa.new
+
+    teste.run # roda o teste
+
     @pessoa.nome = 'Sem nome'
-    puts ">>>>>>>> DEPOIS DE CADA TESTE <<<<<<<< #{@pessoa.inspect}"
-    puts " "
+    puts "DEPOISSSS"
   end
 
   it 'have_attributes' do


### PR DESCRIPTION
feat: Add before and after hooks to attribute tests

The code changes include adding `before` and `after` hooks to the attribute tests in the `atributos_spec.rb` file. These hooks are used to set up and tear down the test environment before and after each test case. The purpose of these changes is to ensure that the `@pessoa` object is properly initialized before each test and reset to its default state after each test.