### PR TITLE
feat: Add before and after hooks to attribute tests

### DIFF
--- a/spec/matchers/atributos/atributos_let_spec.rb
+++ b/spec/matchers/atributos/atributos_let_spec.rb
@@ -1,0 +1,25 @@
+require 'pessoa'
+
+describe 'Atributos' do
+  # before(:each) do
+  #   @pessoa = Pessoa.new
+  # end
+
+  let(:pessoa) { Pessoa.new }
+
+  it 'have_attributes' do
+    pessoa.nome = 'Bruno'
+    pessoa.idade = 20
+    puts pessoa.inspect
+
+    expect(pessoa).to have_attributes(nome: a_string_starting_with('B'), idade: (a_value >= 20))
+  end
+
+  it 'have_attributes' do
+    pessoa.nome = 'Jose'
+    pessoa.idade = 25
+    puts pessoa.inspect
+
+    expect(pessoa).to have_attributes(nome: a_string_starting_with('J'), idade: (a_value >= 20))
+  end
+end

--- a/spec/matchers/let/let_bang_spec.rb
+++ b/spec/matchers/let/let_bang_spec.rb
@@ -1,0 +1,20 @@
+$COUNT = 0
+
+describe "let!" do
+  ordem_de_invocacao = []
+
+  let!(:contador) do # let! é executado antes do teste
+    ordem_de_invocacao << :let!
+    $COUNT += 1
+  end
+
+  it 'chama o método helper antes do teste' do
+    ordem_de_invocacao << :exemplo
+
+    expect(ordem_de_invocacao).to eq( [:let!, :exemplo] )
+    puts "ordem_de_invocacao: #{ordem_de_invocacao}"
+
+    expect(contador).to eq(1)
+    puts "contador: #{contador}"
+  end
+end

--- a/spec/matchers/let/let_spec.rb
+++ b/spec/matchers/let/let_spec.rb
@@ -1,0 +1,16 @@
+$COUNTER = 0 # variável global
+
+describe 'let' do
+  let(:count) { $COUNTER += 1 } # toda vez que chamar count, vai incrementar 1 quando for um novo teste
+
+  it 'memoriza o valor' do
+    expect(count).to eq(1) # 1a vez é carregado
+    expect(count).to eq(1) # 2a vez é memorizado
+    puts count
+  end
+
+  it 'não é cacheado entre os testes' do
+    expect(count).to eq(2) # 1a vez é carregado mas vai pegar o valor que já esta em cache
+    puts count
+  end
+end


### PR DESCRIPTION
Here I use let and let! where let loads before each test once, only storing the value of the variable in cache and let! is run before testing