### PR TITLE
feat: Add matcher output tests

### DIFF
--- a/spec/matchers/output/output_spec.rb
+++ b/spec/matchers/output/output_spec.rb
@@ -1,0 +1,9 @@
+describe 'Matcher output' do
+  it { expect { puts 'Bruno' }.to output.to_stdout } # saída padrão
+  it { expect { print 'Bruno' }.to output('Bruno').to_stdout } # saída padrão
+  it { expect { puts 'Bruno Lima' }.to output(/Bruno/).to_stdout }  # saída padrão usando regex
+
+  it { expect { warn 'Bruno' }.to output.to_stderr } # saída padrão erro
+  it { expect { warn 'Bruno' }.to output("Bruno\n").to_stderr } # saída padrão erro
+  it { expect { warn 'Bruno Lima' }.to output(/Bruno/).to_stderr } # saída padrão erro usanbdo regex
+end


### PR DESCRIPTION
The code changes include adding tests for the matcher output in the `output_spec.rb` file. These tests verify the behavior of the `to_stdout` and `to_stderr` matchers using different scenarios, such as checking the output to standard output and standard error, matching specific strings, and using regular expressions. This addition enhances the test coverage for the output matchers.