### PR TITLE
feat: Add negated matchers for include and be_within

### DIFF
--- a/spec/matchers/arrays/arrays_spec.rb
+++ b/spec/matchers/arrays/arrays_spec.rb
@@ -1,7 +1,11 @@
+RSpec::Matchers.define_negated_matcher :exclude, :include # define um matcher negado
+
 describe Array.new([1, 2, 3]), 'Array testing' do
   it '#include' do
     expect(subject).to include(2, 3) # verifica se contain os elementos separados
   end
+
+  it { expect(subject).to exclude(4)} # verifica se não contém o elemento
 
   it '#contain_exactly' do
     expect(subject).to contain_exactly(1, 2, 3) # verifica se contain os elementos exatos, mas não importa a ordem

--- a/spec/matchers/be_within/be_within_spec.rb
+++ b/spec/matchers/be_within/be_within_spec.rb
@@ -1,7 +1,11 @@
+RSpec::Matchers.define_negated_matcher :be_not_within, :be_within # define um matcher negado
+
 # espero que o numero 12.5 esteja com a diferença de no maximo 0.5 do numero 12
 # exemplo: 11.5, 11.6, 11.7, 11.8, 11.9, 12, 12.1, 12.2, 12.3, 12.4 12.5
 # delta = 0.5
+
 describe 'be_within' do
   it { expect(12.5).to be_within(0.5).of(12.0)}
+  it { expect(11.4).to be_not_within(0.5).of(12.0)}
   it { expect([11.6, 12.1, 12.5]).to all(be_within(0.5).of(12.0))}
 end


### PR DESCRIPTION
The code changes include defining negated matchers for the `include` and `be_within` matchers in the `arrays_spec.rb` and `be_within_spec.rb` files respectively. These negated matchers allow for checking if an element is not included in an array and if a number is not within a certain range. This addition enhances the flexibility and expressiveness of the test assertions.