### PR TITLE
Custom Matcher

### DIFF
--- a/spec/matchers/custom/custom_spec.rb
+++ b/spec/matchers/custom/custom_spec.rb
@@ -1,0 +1,22 @@
+RSpec::Matchers.define :be_a_multiple_of do |expected|
+  # expected == 3
+  # actual == 18
+  # x % 3 == 0   # Aqui verificamos se o número é múltiplo de 3
+  # Esse é um matcher customizado, personalizado
+  match do |actual|
+    actual % expected == 0
+  end
+
+  # Pessonalizando mensagem de erro
+  failure_message do |actual|
+    "expected that #{actual} would be a multiple of #{expected}"
+  end
+
+  description do
+    "be a multiple of #{expected} <<<<<<<<"
+  end
+end
+
+describe 18, "Custom Matcher" do
+  it { is_expected.to be_a_multiple_of(3) }
+end


### PR DESCRIPTION
Add custom matcher for checking if a number is a multiple of a given value

This commit adds a new custom matcher called `be_a_multiple_of` to the `custom_spec.rb` file. The matcher allows for checking if a number is a multiple of a given value. It improves the flexibility and expressiveness of the test assertions.