### PR TITLE
feat: Add example when double test

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -2,7 +2,7 @@
 --format documentation
 
 # filtro para testa somente os collection
---tag type:collection
+# --tag type:collection
 
 # Não vai rodar os teste que tem esta marcação slow
 # --tag ~slow

--- a/spec/test_doubles/test_doubles_spec.rb
+++ b/spec/test_doubles/test_doubles_spec.rb
@@ -1,0 +1,8 @@
+describe 'Test Doubles' do
+  it 'should return a fake value' do
+    user = double('User')
+    allow(user).to receive_messages(name: 'Bruno', password: 'secret')
+    puts user.name
+    puts user.password
+  end
+end


### PR DESCRIPTION
This commit adds a new test example using doubles to the `test_doubles_spec.rb` file. It demonstrates how to use doubles tests to return false values ​​for a user object. The example creates a double for the `User` class and configures the `name` and `password` methods to return specific values.