### PR TITLE
feat: Add factory_bot_rails gem for test_app

### DIFF
--- a/test_app/.rspec
+++ b/test_app/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/test_app/Gemfile
+++ b/test_app/Gemfile
@@ -40,6 +40,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '~> 5.0.0'
+  gem 'factory_bot_rails'
 end
 
 group :development do

--- a/test_app/Gemfile.lock
+++ b/test_app/Gemfile.lock
@@ -62,6 +62,11 @@ GEM
     digest (3.1.1)
     erubi (1.13.0)
     execjs (2.9.1)
+    factory_bot (6.2.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
     ffi (1.17.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -212,6 +217,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   coffee-rails (~> 4.2)
+  factory_bot_rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.11)

--- a/test_app/spec/factories/customer.rb
+++ b/test_app/spec/factories/customer.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :customer do
+    name { "Bruno Lima" }
+    email { "brunolima@gmail.com" }
+  end
+end

--- a/test_app/spec/models/customer_spec.rb
+++ b/test_app/spec/models/customer_spec.rb
@@ -1,15 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Customer, type: :model do
-  fixtures :customers
 
   it 'Createa Customer' do
-    customer = customers(:bruno)
-
-    # subject.name = 'Bruno Lima'
-    # subject.email = 'brunolima@gmail.com' // podemos troca essa parte por FIXTURES
-    # subject.save
-
+    customer = create(:customer)
     expect(customer.full_name).to eq('Sr. Bruno Lima')
   end
 end

--- a/test_app/spec/rails_helper.rb
+++ b/test_app/spec/rails_helper.rb
@@ -31,6 +31,10 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+
+  # Factory Bot
+  config.include FactoryBot::Syntax::Methods
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # Seguindo esta configuração, crio a pasta fixtures dentro da pasta spec
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
This commit adds the `factory_bot_rails` gem to the `Gemfile` of the `test_app` project. This gem is necessary for using FactoryBot to create test data in the project's model tests.