### PR TITLE
feat: Add VIP and days to pay columns to customers table

### DIFF
--- a/test_app/db/migrate/20240704003809_create_customers.rb
+++ b/test_app/db/migrate/20240704003809_create_customers.rb
@@ -3,6 +3,8 @@ class CreateCustomers < ActiveRecord::Migration[5.2]
     create_table :customers do |t|
       t.string :name
       t.string :email
+      t.boolean :vip
+      t.integer :days_to_pay
 
       t.timestamps
     end

--- a/test_app/db/schema.rb
+++ b/test_app/db/schema.rb
@@ -15,6 +15,8 @@ ActiveRecord::Schema.define(version: 2024_07_04_003809) do
   create_table "customers", force: :cascade do |t|
     t.string "name"
     t.string "email"
+    t.boolean "vip"
+    t.integer "days_to_pay"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test_app/spec/factories/customer.rb
+++ b/test_app/spec/factories/customer.rb
@@ -2,5 +2,15 @@ FactoryBot.define do
   factory :customer, aliases: [:user] do
     name { Faker::Name.name }
     email { Faker::Internet.email }
+
+    factory :customer_vip do
+      vip { true }
+      days_to_pay { 30 }
+    end
+
+    factory :customer_default do
+      vip { false }
+      days_to_pay { 15 }
+    end
   end
 end

--- a/test_app/spec/models/customer_spec.rb
+++ b/test_app/spec/models/customer_spec.rb
@@ -7,6 +7,16 @@ RSpec.describe Customer, type: :model do
     expect(customer.full_name).to start_with('Sr. ')
   end
 
+  it 'customer_vip (Herença)' do
+    customer = create(:customer_vip)
+    expect(customer.vip).to be(true)
+  end
+
+  it 'customer_default (Herença)' do
+    customer = create(:customer_default)
+    expect(customer.vip).to be(false)
+  end
+
   it 'full_name - Sobrescrevendo atributo' do
     customer = create(:customer, name: 'Bruno Lima')
     expect(customer.full_name).to start_with('Sr. Bruno Lima')


### PR DESCRIPTION
This commit adds the `vip` and `days_to_pay` columns to the `customers` table in the database migration and schema files. It also updates the customer factory to include the `:customer_vip` and `:customer_default` aliases, allowing us to create customers with different VIP statuses and days to pay in our tests.