### PR TITLE
feat: Update upcased attribute in customer_spec.rb test case

### DIFF
--- a/test_app/spec/models/customer_spec.rb
+++ b/test_app/spec/models/customer_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Customer, type: :model do
   end
 
   it 'Atributo transitorio' do
-    customer = create(:customer_default, upcased: false) # upcased recebe true
+    customer = create(:customer_default, upcased: true) # upcased recebe true
     expect(customer.name.upcase).to eq(customer.name)
   end
 end


### PR DESCRIPTION
This commit updates the `upcased` attribute in the `customer_spec.rb` test case to set it to `true` instead of `false`. This change ensures that the `name` attribute is correctly upcased when the `upcased` attribute is `true`.