### PR TITLE
🙌 feat: Add Order model and migration belongs_to

### DIFF
--- a/test_app/app/models/order.rb
+++ b/test_app/app/models/order.rb
@@ -1,0 +1,3 @@
+class Order < ApplicationRecord
+  belongs_to :customer
+end

--- a/test_app/db/migrate/20240805223619_create_orders.rb
+++ b/test_app/db/migrate/20240805223619_create_orders.rb
@@ -1,0 +1,10 @@
+class CreateOrders < ActiveRecord::Migration[5.2]
+  def change
+    create_table :orders do |t|
+      t.string :description
+      t.references :customer, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/test_app/db/schema.rb
+++ b/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_04_003809) do
+ActiveRecord::Schema.define(version: 2024_08_05_223619) do
 
   create_table "customers", force: :cascade do |t|
     t.string "name"
@@ -19,6 +19,14 @@ ActiveRecord::Schema.define(version: 2024_07_04_003809) do
     t.integer "days_to_pay"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.string "description"
+    t.integer "customer_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_orders_on_customer_id"
   end
 
 end

--- a/test_app/spec/factories/orders.rb
+++ b/test_app/spec/factories/orders.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :order do
+    sequence(:description) { |n| "Pedido número - #{n} (fábrica == factory)" }
+    association :customer, factory: :customer
+    # customer é a mesma coisa que => association :customer, factory: :customer
+  end
+end

--- a/test_app/spec/models/order_spec.rb
+++ b/test_app/spec/models/order_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  it 'Tem 1 pedido' do
+    # customer = create(:customer)
+    # order = create(:order, customer: customer)
+    order = create(:order)
+    # puts order.description
+    # puts order.customer
+    # puts order.customer.name
+    expect(order.customer).to be_kind_of(Customer)
+  end
+end


### PR DESCRIPTION
This commit adds the Order model and migration files. The Order model belongs to a Customer and has a description attribute. The migration file creates the orders table with the necessary columns.